### PR TITLE
add table caption element

### DIFF
--- a/src/template_element.js
+++ b/src/template_element.js
@@ -366,6 +366,7 @@
     'TD': true,
     'COLGROUP': true,
     'COL': true,
+    'CAPTION': true,
     'OPTION': true
   };
 


### PR DESCRIPTION
I noticed that `<caption>` was not treated as a table element. I had some other code with a list of table elements, and the only difference was the inclusion of caption.

I'm not sure why you'd want to put a template on a caption :), but figured it might be worth including for completeness?

(AFAIK, repeat wouldn't make sense on `<caption>` because you only have one, but maybe "bind" or "ref" would be meaningful?)

Spec: http://www.whatwg.org/specs/web-apps/current-work/multipage/tabular-data.html#the-caption-element
