### PR TITLE
remove unused isCheckBoxOrRadioButton

### DIFF
--- a/src/template_element.js
+++ b/src/template_element.js
@@ -741,10 +741,6 @@
     return result;
   }
 
-  function isCheckBoxOrRadioButton(element) {
-    return element.type === 'radio' || element.type === 'checkbox';
-  }
-
   function bindOrDelegate(node, name, model, path, syntax) {
     var delegateBinding;
     var delegate = syntax && syntax[GET_BINDING];


### PR DESCRIPTION
It doesn't seem like this method is used anymore.
