### PR TITLE
remove extra argument to extractInstanceAt

### DIFF
--- a/src/template_element.js
+++ b/src/template_element.js
@@ -1360,7 +1360,7 @@
       splices.forEach(function(splice) {
         splice.removed.forEach(function(model) {
           var instanceNodes =
-              this.extractInstanceAt(splice.index + removeDelta, instanceNodes);
+              this.extractInstanceAt(splice.index + removeDelta);
           instanceCache.set(model, instanceNodes);
         }, this);
 


### PR DESCRIPTION
There seems to be an extra argument passed to this function, as extractInstanceAt only takes 1 arg (the index).
I ran tests/index.html before and after and it all looks good.
