### PR TITLE
remove a templateIteratorTable.delete(this) that looks like no-op

### DIFF
--- a/src/template_element.js
+++ b/src/template_element.js
@@ -1275,7 +1275,6 @@
 
       if (!this.inputs.size) {
         // End iteration
-        templateIteratorTable.delete(this);
         this.abandon();
       }
     },
@@ -1349,7 +1348,6 @@
       var template = this.templateElement_;
       if (!template.parentNode || !template.ownerDocument.defaultView) {
         this.abandon();
-        templateIteratorTable.delete(this);
         return;
       }
 


### PR DESCRIPTION
As far as I can tell, the `templateIteratorTable` only uses Nodes as keys. So .delete using the TemplateIterator itself as the key doesn't do anything. Maybe this code is intending to go through the nodes created by the TemplateIterator instead, and remove the pointers back to it?

I tried to see if this code was live by adding a `if (templateIteratorTable.get(this)) { throw '!!! templateIteratorTable present'; }`. It was not hit by the tests (in Chrome and Firefox). So it looks like these two lines can be removed, if I'm understanding this code correctly.
