### PR TITLE
Add support for empty if, similar to bind and repeat.

### DIFF
--- a/src/template_element.js
+++ b/src/template_element.js
@@ -991,6 +991,7 @@
       if (isTemplateNode) {
         if (name === IF) {
           ifFound = true;
+          value = value || '{{}}';  // Accept 'naked' if.
         } else if (name === BIND || name === REPEAT) {
           bindFound = true;
           value = value || '{{}}';  // Accept 'naked' bind & repeat.

--- a/tests/template_element.js
+++ b/tests/template_element.js
@@ -162,6 +162,20 @@ suite('Template Element', function() {
     assert.strictEqual('foo', div.lastChild.textContent);
   });
 
+  test('Template-Empty If', function() {
+    var div = createTestHtml(
+        '<template if>{{ value }}</template>');
+    var m = { value: 'foo' };
+    recursivelySetTemplateModel(div, null);
+    Platform.performMicrotaskCheckpoint();
+    assert.strictEqual(1, div.childNodes.length);
+
+    recursivelySetTemplateModel(div, m);
+    Platform.performMicrotaskCheckpoint();
+    assert.strictEqual(2, div.childNodes.length);
+    assert.strictEqual('foo', div.lastChild.textContent);
+  });
+
   test('Template Repeat If', function() {
     var div = createTestHtml(
         '<template repeat="{{ foo }}" if="{{ bar }}">{{ }}</template>');


### PR DESCRIPTION
Now that `if` implies `bind`, it seems natural if they have the same behavior when the attribute is empty. This gives an easy answer to cases like the one in https://github.com/Polymer/mdv/issues/128.
