### PR TITLE
Enable bindingDelegate getter without bind attr

### DIFF
--- a/src/TemplateBinding.js
+++ b/src/TemplateBinding.js
@@ -507,7 +507,7 @@
     },
 
     get bindingDelegate() {
-      return this.delegate_.raw;
+      return this.delegate_ && this.delegate_.raw;
     },
 
     setDelegate_: function(delegate) {

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -90,6 +90,13 @@ suite('Template Instantiation', function() {
     target.dispatchEvent(event);
   }
 
+  test('accessing bindingDelegate getter without Bind', function(done) {
+    var div = createTestHtml('<template></template>');
+    var template = div.firstChild;
+    assert.strictEqual(template.bindingDelegate, undefined);
+    done();
+  });
+
   test('Bind', function(done) {
     var div = createTestHtml(
         '<template bind={{}}>text</template>');


### PR DESCRIPTION
Accessing the bindingDelegate of a <template> without a bind attribute causes horrible errors: 

```
TypeError: Cannot read property 'raw' of undefined
```

Culprit: https://github.com/Polymer/TemplateBinding/commit/23ef8f16ba0dc751d279cc179989851ec0ad00e1#diff-bb73baf1485cd281bcda48f60572ba1cR486

cc @rafaelw
