### PR TITLE
Alter the test then function a little

### DIFF
--- a/tests/tests.js
+++ b/tests/tests.js
@@ -28,15 +28,20 @@ function doTeardown() {
   assert.strictEqual(0, Observer._allObserversCount);
 }
 
-function then(fn) {
+function then(fn, n) {
+  // We need to ensure that all chained calls are not grouped into the same
+  // setTimeout bucket. This is to allow other scheduled functions to have a go
+  // too.
+  n = n || 10;
   setTimeout(function() {
     Platform.performMicrotaskCheckpoint();
     fn();
-  }, 0);
+  }, n);
 
   return {
     then: function(next) {
-      return then(next);
+      n += 10;
+      return then(next, n);
     }
   };
 }


### PR DESCRIPTION
Before this change all the chained then calls got grouped into the
same setTimeout bucket, which meant that other setTimeouts all get
called after all the then chained calls.

Fixes https://github.com/Polymer/ShadowDOM/issues/412
