### PR TITLE
Don't call filters/functions twice when repeated.

### DIFF
--- a/src/TemplateBinding.js
+++ b/src/TemplateBinding.js
@@ -1023,7 +1023,7 @@
 
       var value = this.deps.value;
       if (!this.deps.oneTime)
-        value = value.discardChanges();
+        value = value.value_;
       if (!this.deps.repeat)
         value = [value];
       var observe = this.deps.repeat &&


### PR DESCRIPTION
Fixes #174 

However, before this is committable:
- `ObserverTransform#value_` seems wrong. Should I add an `ObserverTransform#getValue`?

Also, this raises a related question:
- Should we really be binding at all to repeated values via functions?

---

Why does this work?
1. In `TemplateIterator#updateDependencies`, we [create **and `open`** the `ObserverTransform`](https://github.com/Polymer/TemplateBinding/blob/master/src/TemplateBinding.js#L1000) for the filtered value.
2. The `ObserverTransform` [reads the value of the function in `open`](https://github.com/Polymer/observe-js/blob/master/src/observe.js#L1209)
3. `updateDependencies` -> `updateIteratedValue`.
4. In `updateIteratedValue`, we read the value via discardChanges; which [causes the function to be called](https://github.com/Polymer/observe-js/blob/master/src/observe.js#L1223) again.
5. Finally, the array observer is set up.
