### PR TITLE
Make package.json main point to src/TemplateBinding.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "TemplateBinding",
   "version": "0.0.0",
   "description": "",
-  "main": "grunt.js",
+  "main": "./src/TemplateBinding.js",
   "directories": {
     "doc": "docs",
     "test": "tests"


### PR DESCRIPTION
Not sure if `grunt.js` necessary as the main in `package.json`, but it makes usage with node painful: `require 'TemplateBinding/src/TemplateBinding'`. With this change it's a little more reasonable: `require 'TemplateBinding'`.
