### PR TITLE
fix one time mustache parsing

### DIFF
--- a/src/TemplateBinding.js
+++ b/src/TemplateBinding.js
@@ -670,7 +670,15 @@
         terminator = ']]';
       }
 
-      endIndex = startIndex < 0 ? -1 : s.indexOf(terminator, startIndex + 2);
+      if (startIndex >= 0) {
+        endIndex = s.indexOf(terminator, startIndex + 2);
+        // Handle this case [[foo['bar']]] and others like it.
+        while (s.length > endIndex + 2 && s[endIndex + 2] == terminator[0]) {
+          endIndex++;
+        }
+      } else {
+        endIndex = -1;
+      }
 
       if (endIndex < 0) {
         if (!tokens)

--- a/test/tests.js
+++ b/test/tests.js
@@ -634,6 +634,22 @@ suite('Template Instantiation', function() {
     });
   });
 
+  test('OneTime - list/map', function(done) {
+    var div = createTestHtml(
+        '<template bind>' +
+          '<div foo="[[foo[\'bar\']]]:[[zap[0]]]"></div>' +
+        '</template>');
+    var template = div.firstChild;
+    var m = { foo: {'bar': 'baz'}, zap: ['zip'] };
+    template.model = m;
+
+    then(function() {
+      assert.strictEqual(2, div.childNodes.length);
+      assert.strictEqual('baz:zip', div.lastChild.getAttribute('foo'));
+      done();
+    });
+  });
+
   test('OneTime/Dynamic Mixed - compound attribute', function(done) {
     var div = createTestHtml(
         '<template bind>' +


### PR DESCRIPTION
This fixes one time bindings parsing when using list or map accessors so a trailing space is no longer required:

[[foo['bar']]] now works where you  used to have to do [[foo['bar'] ]]
