### PR TITLE
`this` is not guaranteed to be the root scope

### DIFF
--- a/src/TemplateBinding.js
+++ b/src/TemplateBinding.js
@@ -1283,4 +1283,4 @@
 
   // Polyfill-specific API.
   HTMLTemplateElement.forAllTemplatesFrom_ = forAllTemplatesFrom;
-})(this);
+})(window);


### PR DESCRIPTION
Better to be explicit and use `window`.
